### PR TITLE
Fixing s3 permissions

### DIFF
--- a/pipeline-template.yml
+++ b/pipeline-template.yml
@@ -383,7 +383,8 @@ Resources:
                   - s3:GetBucketVersioning
                 Resource: 
                   - !GetAtt RolesRepository.Arn
-                  - arn:aws:s3:::rolespipelinestack-*
+                  - !GetAtt RolesBucket.Arn
+                  - !GetAtt CodePipelineArtifactStoreBucket.Arn
               - Effect: Allow
                 Action:
                   - access-analyzer:ValidatePolicy


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If cfn stack name is changed from anything other than "rolespipelinestack", then s3 bucket permissions are broken.  This change declares the bucket arn's directly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
